### PR TITLE
Allow using new versions of openai

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule AI.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:openai, "~> 0.5.2"},
+      {:openai, "> 0.5.2"},
       {:ex_doc, "~> 0.14", only: :dev, runtime: false}
     ]
   end


### PR DESCRIPTION
The OpenAI library is into version 0.6 series now: https://github.com/mgallo/openai.ex/releases

This `AI` library supports new versions. The hardcoding of version `0.5.x` causes errors

> Because your app depends on ai ~> 0.3.4 which depends on openai ~> 0.5.2, openai ~> 0.5.2 is required.
> So, because your app depends on openai ~> 0.6.1, version solving failed.

This pull request fixes the error and supports new versions.